### PR TITLE
Dart SASS, division migrated

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,10 @@
 module.exports = function(grunt) {
 
     require("load-grunt-tasks")(grunt);
+    grunt.loadNpmTasks('grunt-dart-sass');
 
     grunt.initConfig({
-        sass: {
+        'dart-sass': {
             production: {
                 options: {
                     style: 'expanded'
@@ -19,7 +20,7 @@ module.exports = function(grunt) {
                     'shoptet.scss',
                     'shoptet/*.scss',
                 ],
-                tasks: ['sass'],
+                tasks: ['dart-sass'],
                 options: {
                     livereload: 35729
                 }
@@ -27,6 +28,6 @@ module.exports = function(grunt) {
         }
     });
 
-    grunt.registerTask('default', ['sass']);
+    grunt.registerTask('default', ['dart-sass']);
 
 };

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   "devDependencies": {
     "grunt": "^1.0.2",
     "grunt-cli": "^1.2.0",
-    "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-watch": "^1.0.1",
-    "load-grunt-tasks": "^4.0.0"
+    "grunt-dart-sass": "^2.0.1",
+    "load-grunt-tasks": "^4.0.0",
+    "sass": "^1.38.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,10 +14,8 @@
     "grunt": "^1.4.1",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-watch": "^1.1.0",
+    "grunt-dart-sass": "^2.0.1",
     "load-grunt-tasks": "^5.1.0",
     "sass": "^1.38.2"
-  },
-  "dependencies": {
-    "grunt-dart-sass": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "url": "https://github.com/Shoptet/microsite-styles/issues"
   },
   "devDependencies": {
-    "grunt": "^1.0.2",
-    "grunt-cli": "^1.2.0",
-    "grunt-contrib-watch": "^1.0.1",
-    "grunt-dart-sass": "^2.0.1",
-    "load-grunt-tasks": "^4.0.0",
+    "grunt": "^1.4.1",
+    "grunt-cli": "^1.4.3",
+    "grunt-contrib-watch": "^1.1.0",
+    "load-grunt-tasks": "^5.1.0",
     "sass": "^1.38.2"
+  },
+  "dependencies": {
+    "grunt-dart-sass": "^2.0.1"
   }
 }

--- a/shoptet.css
+++ b/shoptet.css
@@ -85,7 +85,7 @@ dt {
 }
 
 dd {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   margin-left: 0;
 }
 
@@ -115,11 +115,11 @@ sup {
 }
 
 sub {
-  bottom: -.25em;
+  bottom: -0.25em;
 }
 
 sup {
-  top: -.5em;
+  top: -0.5em;
 }
 
 a {
@@ -225,30 +225,30 @@ select {
 }
 
 button,
-html [type="button"],
-[type="reset"],
-[type="submit"] {
+html [type=button],
+[type=reset],
+[type=submit] {
   -webkit-appearance: button;
 }
 
 button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
+[type=button]::-moz-focus-inner,
+[type=reset]::-moz-focus-inner,
+[type=submit]::-moz-focus-inner {
   padding: 0;
   border-style: none;
 }
 
-input[type="radio"],
-input[type="checkbox"] {
+input[type=radio],
+input[type=checkbox] {
   box-sizing: border-box;
   padding: 0;
 }
 
-input[type="date"],
-input[type="time"],
-input[type="datetime-local"],
-input[type="month"] {
+input[type=date],
+input[type=time],
+input[type=datetime-local],
+input[type=month] {
   -webkit-appearance: listbox;
 }
 
@@ -269,7 +269,7 @@ legend {
   width: 100%;
   max-width: 100%;
   padding: 0;
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   font-size: 1.5rem;
   line-height: inherit;
   color: inherit;
@@ -280,18 +280,18 @@ progress {
   vertical-align: baseline;
 }
 
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
   height: auto;
 }
 
-[type="search"] {
+[type=search] {
   outline-offset: -2px;
   -webkit-appearance: none;
 }
 
-[type="search"]::-webkit-search-cancel-button,
-[type="search"]::-webkit-search-decoration {
+[type=search]::-webkit-search-cancel-button,
+[type=search]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
@@ -391,17 +391,17 @@ template {
   margin-left: 0;
 }
 .no-gutters > .col,
-.no-gutters > [class*="col-"] {
+.no-gutters > [class*=col-] {
   padding-right: 0;
   padding-left: 0;
 }
 
-.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col,
-.col-auto, .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm,
-.col-sm-auto, .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .col-md,
-.col-md-auto, .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg,
-.col-lg-auto, .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12, .col-xl,
-.col-xl-auto {
+.col-xl,
+.col-xl-auto, .col-xl-12, .col-xl-11, .col-xl-10, .col-xl-9, .col-xl-8, .col-xl-7, .col-xl-6, .col-xl-5, .col-xl-4, .col-xl-3, .col-xl-2, .col-xl-1, .col-lg,
+.col-lg-auto, .col-lg-12, .col-lg-11, .col-lg-10, .col-lg-9, .col-lg-8, .col-lg-7, .col-lg-6, .col-lg-5, .col-lg-4, .col-lg-3, .col-lg-2, .col-lg-1, .col-md,
+.col-md-auto, .col-md-12, .col-md-11, .col-md-10, .col-md-9, .col-md-8, .col-md-7, .col-md-6, .col-md-5, .col-md-4, .col-md-3, .col-md-2, .col-md-1, .col-sm,
+.col-sm-auto, .col-sm-12, .col-sm-11, .col-sm-10, .col-sm-9, .col-sm-8, .col-sm-7, .col-sm-6, .col-sm-5, .col-sm-4, .col-sm-3, .col-sm-2, .col-sm-1, .col,
+.col-auto, .col-12, .col-11, .col-10, .col-9, .col-8, .col-7, .col-6, .col-5, .col-4, .col-3, .col-2, .col-1 {
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -1451,7 +1451,7 @@ mark,
   color: #6c757d;
 }
 .blockquote-footer::before {
-  content: "\2014 \00A0";
+  content: "— ";
 }
 
 .btn {
@@ -1489,7 +1489,6 @@ mark,
 .btn:not(:disabled):not(.disabled):active, .btn:not(:disabled):not(.disabled).active {
   background-image: none;
 }
-
 a.btn.disabled,
 fieldset:disabled a.btn {
   pointer-events: none;
@@ -2024,9 +2023,9 @@ fieldset:disabled a.btn {
   margin-top: 0.5rem;
 }
 
-input[type="submit"].btn-block,
-input[type="reset"].btn-block,
-input[type="button"].btn-block {
+input[type=submit].btn-block,
+input[type=reset].btn-block,
+input[type=button].btn-block {
   width: 100%;
 }
 
@@ -2183,7 +2182,7 @@ select.form-control-lg:not([size]):not([multiple]), .input-group-lg > select.for
   margin-left: -5px;
 }
 .form-row > .col,
-.form-row > [class*="col-"] {
+.form-row > [class*=col-] {
   padding-right: 5px;
   padding-left: 5px;
 }
@@ -2234,13 +2233,13 @@ select.form-control-lg:not([size]):not([multiple]), .input-group-lg > select.for
   z-index: 5;
   display: none;
   max-width: 100%;
-  padding: .5rem;
-  margin-top: .1rem;
-  font-size: .875rem;
+  padding: 0.5rem;
+  margin-top: 0.1rem;
+  font-size: 0.875rem;
   line-height: 1;
   color: #fff;
   background-color: rgba(166, 199, 33, 0.8);
-  border-radius: .2rem;
+  border-radius: 0.2rem;
 }
 
 .was-validated .form-control:valid, .form-control.is-valid,
@@ -2326,13 +2325,13 @@ select.form-control-lg:not([size]):not([multiple]), .input-group-lg > select.for
   z-index: 5;
   display: none;
   max-width: 100%;
-  padding: .5rem;
-  margin-top: .1rem;
-  font-size: .875rem;
+  padding: 0.5rem;
+  margin-top: 0.1rem;
+  font-size: 0.875rem;
   line-height: 1;
   color: #fff;
   background-color: rgba(220, 53, 69, 0.8);
-  border-radius: .2rem;
+  border-radius: 0.2rem;
 }
 
 .was-validated .form-control:invalid, .form-control.is-invalid,
@@ -2435,7 +2434,7 @@ select.form-control-lg:not([size]):not([multiple]), .input-group-lg > select.for
     display: inline-block;
   }
   .form-inline .input-group,
-  .form-inline .custom-select {
+.form-inline .custom-select {
     width: auto;
   }
   .form-inline .form-check {
@@ -2790,8 +2789,8 @@ select.form-control-lg:not([size]):not([multiple]), .input-group-lg > select.for
 }
 @media screen and (prefers-reduced-motion: reduce) {
   .custom-control-label::before,
-  .custom-file-label,
-  .custom-select {
+.custom-file-label,
+.custom-select {
     transition: none;
   }
 }
@@ -2893,8 +2892,8 @@ select.form-control-lg:not([size]):not([multiple]), .input-group-lg > select.for
   border: 1px solid #d9d9d9;
   border-radius: 0.25rem;
 }
-.input-group-text input[type="radio"],
-.input-group-text input[type="checkbox"] {
+.input-group-text input[type=radio],
+.input-group-text input[type=checkbox] {
   margin-top: 0;
 }
 
@@ -3402,11 +3401,11 @@ pre code {
     border-bottom-right-radius: 0;
   }
   .card-group > .card:first-child .card-img-top,
-  .card-group > .card:first-child .card-header {
+.card-group > .card:first-child .card-header {
     border-top-right-radius: 0;
   }
   .card-group > .card:first-child .card-img-bottom,
-  .card-group > .card:first-child .card-footer {
+.card-group > .card:first-child .card-footer {
     border-bottom-right-radius: 0;
   }
   .card-group > .card:last-child {
@@ -3414,23 +3413,23 @@ pre code {
     border-bottom-left-radius: 0;
   }
   .card-group > .card:last-child .card-img-top,
-  .card-group > .card:last-child .card-header {
+.card-group > .card:last-child .card-header {
     border-top-left-radius: 0;
   }
   .card-group > .card:last-child .card-img-bottom,
-  .card-group > .card:last-child .card-footer {
+.card-group > .card:last-child .card-footer {
     border-bottom-left-radius: 0;
   }
   .card-group > .card:only-child {
     border-radius: 0.25rem;
   }
   .card-group > .card:only-child .card-img-top,
-  .card-group > .card:only-child .card-header {
+.card-group > .card:only-child .card-header {
     border-top-left-radius: 0.25rem;
     border-top-right-radius: 0.25rem;
   }
   .card-group > .card:only-child .card-img-bottom,
-  .card-group > .card:only-child .card-footer {
+.card-group > .card:only-child .card-footer {
     border-bottom-right-radius: 0.25rem;
     border-bottom-left-radius: 0.25rem;
   }
@@ -3438,9 +3437,9 @@ pre code {
     border-radius: 0;
   }
   .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-top,
-  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
-  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-header,
-  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-footer {
+.card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
+.card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-header,
+.card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-footer {
     border-radius: 0;
   }
 }
@@ -3485,12 +3484,12 @@ pre code {
   line-height: 1;
   color: #111;
   text-shadow: 0 1px 0 #fff;
-  opacity: .5;
+  opacity: 0.5;
 }
 .close:hover, .close:focus {
   color: #111;
   text-decoration: none;
-  opacity: .75;
+  opacity: 0.75;
 }
 .close:not(:disabled):not(.disabled) {
   cursor: pointer;
@@ -3542,53 +3541,53 @@ button.close {
   border-style: solid;
 }
 
-.bs-tooltip-top, .bs-tooltip-auto[x-placement^="top"] {
+.bs-tooltip-top, .bs-tooltip-auto[x-placement^=top] {
   padding: 0.4rem 0;
 }
-.bs-tooltip-top .arrow, .bs-tooltip-auto[x-placement^="top"] .arrow {
+.bs-tooltip-top .arrow, .bs-tooltip-auto[x-placement^=top] .arrow {
   bottom: 0;
 }
-.bs-tooltip-top .arrow::before, .bs-tooltip-auto[x-placement^="top"] .arrow::before {
+.bs-tooltip-top .arrow::before, .bs-tooltip-auto[x-placement^=top] .arrow::before {
   top: 0;
   border-width: 0.4rem 0.4rem 0;
   border-top-color: #111;
 }
 
-.bs-tooltip-right, .bs-tooltip-auto[x-placement^="right"] {
+.bs-tooltip-right, .bs-tooltip-auto[x-placement^=right] {
   padding: 0 0.4rem;
 }
-.bs-tooltip-right .arrow, .bs-tooltip-auto[x-placement^="right"] .arrow {
+.bs-tooltip-right .arrow, .bs-tooltip-auto[x-placement^=right] .arrow {
   left: 0;
   width: 0.4rem;
   height: 0.8rem;
 }
-.bs-tooltip-right .arrow::before, .bs-tooltip-auto[x-placement^="right"] .arrow::before {
+.bs-tooltip-right .arrow::before, .bs-tooltip-auto[x-placement^=right] .arrow::before {
   right: 0;
   border-width: 0.4rem 0.4rem 0.4rem 0;
   border-right-color: #111;
 }
 
-.bs-tooltip-bottom, .bs-tooltip-auto[x-placement^="bottom"] {
+.bs-tooltip-bottom, .bs-tooltip-auto[x-placement^=bottom] {
   padding: 0.4rem 0;
 }
-.bs-tooltip-bottom .arrow, .bs-tooltip-auto[x-placement^="bottom"] .arrow {
+.bs-tooltip-bottom .arrow, .bs-tooltip-auto[x-placement^=bottom] .arrow {
   top: 0;
 }
-.bs-tooltip-bottom .arrow::before, .bs-tooltip-auto[x-placement^="bottom"] .arrow::before {
+.bs-tooltip-bottom .arrow::before, .bs-tooltip-auto[x-placement^=bottom] .arrow::before {
   bottom: 0;
   border-width: 0 0.4rem 0.4rem;
   border-bottom-color: #111;
 }
 
-.bs-tooltip-left, .bs-tooltip-auto[x-placement^="left"] {
+.bs-tooltip-left, .bs-tooltip-auto[x-placement^=left] {
   padding: 0 0.4rem;
 }
-.bs-tooltip-left .arrow, .bs-tooltip-auto[x-placement^="left"] .arrow {
+.bs-tooltip-left .arrow, .bs-tooltip-auto[x-placement^=left] .arrow {
   right: 0;
   width: 0.4rem;
   height: 0.8rem;
 }
-.bs-tooltip-left .arrow::before, .bs-tooltip-auto[x-placement^="left"] .arrow::before {
+.bs-tooltip-left .arrow::before, .bs-tooltip-auto[x-placement^=left] .arrow::before {
   left: 0;
   border-width: 0.4rem 0 0.4rem 0.4rem;
   border-left-color: #111;
@@ -4924,22 +4923,22 @@ button.bg-orange:focus {
   }
 
   .mt-sm-0,
-  .my-sm-0 {
+.my-sm-0 {
     margin-top: 0 !important;
   }
 
   .mr-sm-0,
-  .mx-sm-0 {
+.mx-sm-0 {
     margin-right: 0 !important;
   }
 
   .mb-sm-0,
-  .my-sm-0 {
+.my-sm-0 {
     margin-bottom: 0 !important;
   }
 
   .ml-sm-0,
-  .mx-sm-0 {
+.mx-sm-0 {
     margin-left: 0 !important;
   }
 
@@ -4948,22 +4947,22 @@ button.bg-orange:focus {
   }
 
   .mt-sm-1,
-  .my-sm-1 {
+.my-sm-1 {
     margin-top: 0.5rem !important;
   }
 
   .mr-sm-1,
-  .mx-sm-1 {
+.mx-sm-1 {
     margin-right: 0.5rem !important;
   }
 
   .mb-sm-1,
-  .my-sm-1 {
+.my-sm-1 {
     margin-bottom: 0.5rem !important;
   }
 
   .ml-sm-1,
-  .mx-sm-1 {
+.mx-sm-1 {
     margin-left: 0.5rem !important;
   }
 
@@ -4972,22 +4971,22 @@ button.bg-orange:focus {
   }
 
   .mt-sm-2,
-  .my-sm-2 {
+.my-sm-2 {
     margin-top: 1rem !important;
   }
 
   .mr-sm-2,
-  .mx-sm-2 {
+.mx-sm-2 {
     margin-right: 1rem !important;
   }
 
   .mb-sm-2,
-  .my-sm-2 {
+.my-sm-2 {
     margin-bottom: 1rem !important;
   }
 
   .ml-sm-2,
-  .mx-sm-2 {
+.mx-sm-2 {
     margin-left: 1rem !important;
   }
 
@@ -4996,22 +4995,22 @@ button.bg-orange:focus {
   }
 
   .mt-sm-3,
-  .my-sm-3 {
+.my-sm-3 {
     margin-top: 2rem !important;
   }
 
   .mr-sm-3,
-  .mx-sm-3 {
+.mx-sm-3 {
     margin-right: 2rem !important;
   }
 
   .mb-sm-3,
-  .my-sm-3 {
+.my-sm-3 {
     margin-bottom: 2rem !important;
   }
 
   .ml-sm-3,
-  .mx-sm-3 {
+.mx-sm-3 {
     margin-left: 2rem !important;
   }
 
@@ -5020,22 +5019,22 @@ button.bg-orange:focus {
   }
 
   .mt-sm-4,
-  .my-sm-4 {
+.my-sm-4 {
     margin-top: 3rem !important;
   }
 
   .mr-sm-4,
-  .mx-sm-4 {
+.mx-sm-4 {
     margin-right: 3rem !important;
   }
 
   .mb-sm-4,
-  .my-sm-4 {
+.my-sm-4 {
     margin-bottom: 3rem !important;
   }
 
   .ml-sm-4,
-  .mx-sm-4 {
+.mx-sm-4 {
     margin-left: 3rem !important;
   }
 
@@ -5044,22 +5043,22 @@ button.bg-orange:focus {
   }
 
   .mt-sm-5,
-  .my-sm-5 {
+.my-sm-5 {
     margin-top: 6rem !important;
   }
 
   .mr-sm-5,
-  .mx-sm-5 {
+.mx-sm-5 {
     margin-right: 6rem !important;
   }
 
   .mb-sm-5,
-  .my-sm-5 {
+.my-sm-5 {
     margin-bottom: 6rem !important;
   }
 
   .ml-sm-5,
-  .mx-sm-5 {
+.mx-sm-5 {
     margin-left: 6rem !important;
   }
 
@@ -5068,22 +5067,22 @@ button.bg-orange:focus {
   }
 
   .pt-sm-0,
-  .py-sm-0 {
+.py-sm-0 {
     padding-top: 0 !important;
   }
 
   .pr-sm-0,
-  .px-sm-0 {
+.px-sm-0 {
     padding-right: 0 !important;
   }
 
   .pb-sm-0,
-  .py-sm-0 {
+.py-sm-0 {
     padding-bottom: 0 !important;
   }
 
   .pl-sm-0,
-  .px-sm-0 {
+.px-sm-0 {
     padding-left: 0 !important;
   }
 
@@ -5092,22 +5091,22 @@ button.bg-orange:focus {
   }
 
   .pt-sm-1,
-  .py-sm-1 {
+.py-sm-1 {
     padding-top: 0.5rem !important;
   }
 
   .pr-sm-1,
-  .px-sm-1 {
+.px-sm-1 {
     padding-right: 0.5rem !important;
   }
 
   .pb-sm-1,
-  .py-sm-1 {
+.py-sm-1 {
     padding-bottom: 0.5rem !important;
   }
 
   .pl-sm-1,
-  .px-sm-1 {
+.px-sm-1 {
     padding-left: 0.5rem !important;
   }
 
@@ -5116,22 +5115,22 @@ button.bg-orange:focus {
   }
 
   .pt-sm-2,
-  .py-sm-2 {
+.py-sm-2 {
     padding-top: 1rem !important;
   }
 
   .pr-sm-2,
-  .px-sm-2 {
+.px-sm-2 {
     padding-right: 1rem !important;
   }
 
   .pb-sm-2,
-  .py-sm-2 {
+.py-sm-2 {
     padding-bottom: 1rem !important;
   }
 
   .pl-sm-2,
-  .px-sm-2 {
+.px-sm-2 {
     padding-left: 1rem !important;
   }
 
@@ -5140,22 +5139,22 @@ button.bg-orange:focus {
   }
 
   .pt-sm-3,
-  .py-sm-3 {
+.py-sm-3 {
     padding-top: 2rem !important;
   }
 
   .pr-sm-3,
-  .px-sm-3 {
+.px-sm-3 {
     padding-right: 2rem !important;
   }
 
   .pb-sm-3,
-  .py-sm-3 {
+.py-sm-3 {
     padding-bottom: 2rem !important;
   }
 
   .pl-sm-3,
-  .px-sm-3 {
+.px-sm-3 {
     padding-left: 2rem !important;
   }
 
@@ -5164,22 +5163,22 @@ button.bg-orange:focus {
   }
 
   .pt-sm-4,
-  .py-sm-4 {
+.py-sm-4 {
     padding-top: 3rem !important;
   }
 
   .pr-sm-4,
-  .px-sm-4 {
+.px-sm-4 {
     padding-right: 3rem !important;
   }
 
   .pb-sm-4,
-  .py-sm-4 {
+.py-sm-4 {
     padding-bottom: 3rem !important;
   }
 
   .pl-sm-4,
-  .px-sm-4 {
+.px-sm-4 {
     padding-left: 3rem !important;
   }
 
@@ -5188,22 +5187,22 @@ button.bg-orange:focus {
   }
 
   .pt-sm-5,
-  .py-sm-5 {
+.py-sm-5 {
     padding-top: 6rem !important;
   }
 
   .pr-sm-5,
-  .px-sm-5 {
+.px-sm-5 {
     padding-right: 6rem !important;
   }
 
   .pb-sm-5,
-  .py-sm-5 {
+.py-sm-5 {
     padding-bottom: 6rem !important;
   }
 
   .pl-sm-5,
-  .px-sm-5 {
+.px-sm-5 {
     padding-left: 6rem !important;
   }
 
@@ -5212,22 +5211,22 @@ button.bg-orange:focus {
   }
 
   .mt-sm-auto,
-  .my-sm-auto {
+.my-sm-auto {
     margin-top: auto !important;
   }
 
   .mr-sm-auto,
-  .mx-sm-auto {
+.mx-sm-auto {
     margin-right: auto !important;
   }
 
   .mb-sm-auto,
-  .my-sm-auto {
+.my-sm-auto {
     margin-bottom: auto !important;
   }
 
   .ml-sm-auto,
-  .mx-sm-auto {
+.mx-sm-auto {
     margin-left: auto !important;
   }
 }
@@ -5237,22 +5236,22 @@ button.bg-orange:focus {
   }
 
   .mt-md-0,
-  .my-md-0 {
+.my-md-0 {
     margin-top: 0 !important;
   }
 
   .mr-md-0,
-  .mx-md-0 {
+.mx-md-0 {
     margin-right: 0 !important;
   }
 
   .mb-md-0,
-  .my-md-0 {
+.my-md-0 {
     margin-bottom: 0 !important;
   }
 
   .ml-md-0,
-  .mx-md-0 {
+.mx-md-0 {
     margin-left: 0 !important;
   }
 
@@ -5261,22 +5260,22 @@ button.bg-orange:focus {
   }
 
   .mt-md-1,
-  .my-md-1 {
+.my-md-1 {
     margin-top: 0.5rem !important;
   }
 
   .mr-md-1,
-  .mx-md-1 {
+.mx-md-1 {
     margin-right: 0.5rem !important;
   }
 
   .mb-md-1,
-  .my-md-1 {
+.my-md-1 {
     margin-bottom: 0.5rem !important;
   }
 
   .ml-md-1,
-  .mx-md-1 {
+.mx-md-1 {
     margin-left: 0.5rem !important;
   }
 
@@ -5285,22 +5284,22 @@ button.bg-orange:focus {
   }
 
   .mt-md-2,
-  .my-md-2 {
+.my-md-2 {
     margin-top: 1rem !important;
   }
 
   .mr-md-2,
-  .mx-md-2 {
+.mx-md-2 {
     margin-right: 1rem !important;
   }
 
   .mb-md-2,
-  .my-md-2 {
+.my-md-2 {
     margin-bottom: 1rem !important;
   }
 
   .ml-md-2,
-  .mx-md-2 {
+.mx-md-2 {
     margin-left: 1rem !important;
   }
 
@@ -5309,22 +5308,22 @@ button.bg-orange:focus {
   }
 
   .mt-md-3,
-  .my-md-3 {
+.my-md-3 {
     margin-top: 2rem !important;
   }
 
   .mr-md-3,
-  .mx-md-3 {
+.mx-md-3 {
     margin-right: 2rem !important;
   }
 
   .mb-md-3,
-  .my-md-3 {
+.my-md-3 {
     margin-bottom: 2rem !important;
   }
 
   .ml-md-3,
-  .mx-md-3 {
+.mx-md-3 {
     margin-left: 2rem !important;
   }
 
@@ -5333,22 +5332,22 @@ button.bg-orange:focus {
   }
 
   .mt-md-4,
-  .my-md-4 {
+.my-md-4 {
     margin-top: 3rem !important;
   }
 
   .mr-md-4,
-  .mx-md-4 {
+.mx-md-4 {
     margin-right: 3rem !important;
   }
 
   .mb-md-4,
-  .my-md-4 {
+.my-md-4 {
     margin-bottom: 3rem !important;
   }
 
   .ml-md-4,
-  .mx-md-4 {
+.mx-md-4 {
     margin-left: 3rem !important;
   }
 
@@ -5357,22 +5356,22 @@ button.bg-orange:focus {
   }
 
   .mt-md-5,
-  .my-md-5 {
+.my-md-5 {
     margin-top: 6rem !important;
   }
 
   .mr-md-5,
-  .mx-md-5 {
+.mx-md-5 {
     margin-right: 6rem !important;
   }
 
   .mb-md-5,
-  .my-md-5 {
+.my-md-5 {
     margin-bottom: 6rem !important;
   }
 
   .ml-md-5,
-  .mx-md-5 {
+.mx-md-5 {
     margin-left: 6rem !important;
   }
 
@@ -5381,22 +5380,22 @@ button.bg-orange:focus {
   }
 
   .pt-md-0,
-  .py-md-0 {
+.py-md-0 {
     padding-top: 0 !important;
   }
 
   .pr-md-0,
-  .px-md-0 {
+.px-md-0 {
     padding-right: 0 !important;
   }
 
   .pb-md-0,
-  .py-md-0 {
+.py-md-0 {
     padding-bottom: 0 !important;
   }
 
   .pl-md-0,
-  .px-md-0 {
+.px-md-0 {
     padding-left: 0 !important;
   }
 
@@ -5405,22 +5404,22 @@ button.bg-orange:focus {
   }
 
   .pt-md-1,
-  .py-md-1 {
+.py-md-1 {
     padding-top: 0.5rem !important;
   }
 
   .pr-md-1,
-  .px-md-1 {
+.px-md-1 {
     padding-right: 0.5rem !important;
   }
 
   .pb-md-1,
-  .py-md-1 {
+.py-md-1 {
     padding-bottom: 0.5rem !important;
   }
 
   .pl-md-1,
-  .px-md-1 {
+.px-md-1 {
     padding-left: 0.5rem !important;
   }
 
@@ -5429,22 +5428,22 @@ button.bg-orange:focus {
   }
 
   .pt-md-2,
-  .py-md-2 {
+.py-md-2 {
     padding-top: 1rem !important;
   }
 
   .pr-md-2,
-  .px-md-2 {
+.px-md-2 {
     padding-right: 1rem !important;
   }
 
   .pb-md-2,
-  .py-md-2 {
+.py-md-2 {
     padding-bottom: 1rem !important;
   }
 
   .pl-md-2,
-  .px-md-2 {
+.px-md-2 {
     padding-left: 1rem !important;
   }
 
@@ -5453,22 +5452,22 @@ button.bg-orange:focus {
   }
 
   .pt-md-3,
-  .py-md-3 {
+.py-md-3 {
     padding-top: 2rem !important;
   }
 
   .pr-md-3,
-  .px-md-3 {
+.px-md-3 {
     padding-right: 2rem !important;
   }
 
   .pb-md-3,
-  .py-md-3 {
+.py-md-3 {
     padding-bottom: 2rem !important;
   }
 
   .pl-md-3,
-  .px-md-3 {
+.px-md-3 {
     padding-left: 2rem !important;
   }
 
@@ -5477,22 +5476,22 @@ button.bg-orange:focus {
   }
 
   .pt-md-4,
-  .py-md-4 {
+.py-md-4 {
     padding-top: 3rem !important;
   }
 
   .pr-md-4,
-  .px-md-4 {
+.px-md-4 {
     padding-right: 3rem !important;
   }
 
   .pb-md-4,
-  .py-md-4 {
+.py-md-4 {
     padding-bottom: 3rem !important;
   }
 
   .pl-md-4,
-  .px-md-4 {
+.px-md-4 {
     padding-left: 3rem !important;
   }
 
@@ -5501,22 +5500,22 @@ button.bg-orange:focus {
   }
 
   .pt-md-5,
-  .py-md-5 {
+.py-md-5 {
     padding-top: 6rem !important;
   }
 
   .pr-md-5,
-  .px-md-5 {
+.px-md-5 {
     padding-right: 6rem !important;
   }
 
   .pb-md-5,
-  .py-md-5 {
+.py-md-5 {
     padding-bottom: 6rem !important;
   }
 
   .pl-md-5,
-  .px-md-5 {
+.px-md-5 {
     padding-left: 6rem !important;
   }
 
@@ -5525,22 +5524,22 @@ button.bg-orange:focus {
   }
 
   .mt-md-auto,
-  .my-md-auto {
+.my-md-auto {
     margin-top: auto !important;
   }
 
   .mr-md-auto,
-  .mx-md-auto {
+.mx-md-auto {
     margin-right: auto !important;
   }
 
   .mb-md-auto,
-  .my-md-auto {
+.my-md-auto {
     margin-bottom: auto !important;
   }
 
   .ml-md-auto,
-  .mx-md-auto {
+.mx-md-auto {
     margin-left: auto !important;
   }
 }
@@ -5550,22 +5549,22 @@ button.bg-orange:focus {
   }
 
   .mt-lg-0,
-  .my-lg-0 {
+.my-lg-0 {
     margin-top: 0 !important;
   }
 
   .mr-lg-0,
-  .mx-lg-0 {
+.mx-lg-0 {
     margin-right: 0 !important;
   }
 
   .mb-lg-0,
-  .my-lg-0 {
+.my-lg-0 {
     margin-bottom: 0 !important;
   }
 
   .ml-lg-0,
-  .mx-lg-0 {
+.mx-lg-0 {
     margin-left: 0 !important;
   }
 
@@ -5574,22 +5573,22 @@ button.bg-orange:focus {
   }
 
   .mt-lg-1,
-  .my-lg-1 {
+.my-lg-1 {
     margin-top: 0.5rem !important;
   }
 
   .mr-lg-1,
-  .mx-lg-1 {
+.mx-lg-1 {
     margin-right: 0.5rem !important;
   }
 
   .mb-lg-1,
-  .my-lg-1 {
+.my-lg-1 {
     margin-bottom: 0.5rem !important;
   }
 
   .ml-lg-1,
-  .mx-lg-1 {
+.mx-lg-1 {
     margin-left: 0.5rem !important;
   }
 
@@ -5598,22 +5597,22 @@ button.bg-orange:focus {
   }
 
   .mt-lg-2,
-  .my-lg-2 {
+.my-lg-2 {
     margin-top: 1rem !important;
   }
 
   .mr-lg-2,
-  .mx-lg-2 {
+.mx-lg-2 {
     margin-right: 1rem !important;
   }
 
   .mb-lg-2,
-  .my-lg-2 {
+.my-lg-2 {
     margin-bottom: 1rem !important;
   }
 
   .ml-lg-2,
-  .mx-lg-2 {
+.mx-lg-2 {
     margin-left: 1rem !important;
   }
 
@@ -5622,22 +5621,22 @@ button.bg-orange:focus {
   }
 
   .mt-lg-3,
-  .my-lg-3 {
+.my-lg-3 {
     margin-top: 2rem !important;
   }
 
   .mr-lg-3,
-  .mx-lg-3 {
+.mx-lg-3 {
     margin-right: 2rem !important;
   }
 
   .mb-lg-3,
-  .my-lg-3 {
+.my-lg-3 {
     margin-bottom: 2rem !important;
   }
 
   .ml-lg-3,
-  .mx-lg-3 {
+.mx-lg-3 {
     margin-left: 2rem !important;
   }
 
@@ -5646,22 +5645,22 @@ button.bg-orange:focus {
   }
 
   .mt-lg-4,
-  .my-lg-4 {
+.my-lg-4 {
     margin-top: 3rem !important;
   }
 
   .mr-lg-4,
-  .mx-lg-4 {
+.mx-lg-4 {
     margin-right: 3rem !important;
   }
 
   .mb-lg-4,
-  .my-lg-4 {
+.my-lg-4 {
     margin-bottom: 3rem !important;
   }
 
   .ml-lg-4,
-  .mx-lg-4 {
+.mx-lg-4 {
     margin-left: 3rem !important;
   }
 
@@ -5670,22 +5669,22 @@ button.bg-orange:focus {
   }
 
   .mt-lg-5,
-  .my-lg-5 {
+.my-lg-5 {
     margin-top: 6rem !important;
   }
 
   .mr-lg-5,
-  .mx-lg-5 {
+.mx-lg-5 {
     margin-right: 6rem !important;
   }
 
   .mb-lg-5,
-  .my-lg-5 {
+.my-lg-5 {
     margin-bottom: 6rem !important;
   }
 
   .ml-lg-5,
-  .mx-lg-5 {
+.mx-lg-5 {
     margin-left: 6rem !important;
   }
 
@@ -5694,22 +5693,22 @@ button.bg-orange:focus {
   }
 
   .pt-lg-0,
-  .py-lg-0 {
+.py-lg-0 {
     padding-top: 0 !important;
   }
 
   .pr-lg-0,
-  .px-lg-0 {
+.px-lg-0 {
     padding-right: 0 !important;
   }
 
   .pb-lg-0,
-  .py-lg-0 {
+.py-lg-0 {
     padding-bottom: 0 !important;
   }
 
   .pl-lg-0,
-  .px-lg-0 {
+.px-lg-0 {
     padding-left: 0 !important;
   }
 
@@ -5718,22 +5717,22 @@ button.bg-orange:focus {
   }
 
   .pt-lg-1,
-  .py-lg-1 {
+.py-lg-1 {
     padding-top: 0.5rem !important;
   }
 
   .pr-lg-1,
-  .px-lg-1 {
+.px-lg-1 {
     padding-right: 0.5rem !important;
   }
 
   .pb-lg-1,
-  .py-lg-1 {
+.py-lg-1 {
     padding-bottom: 0.5rem !important;
   }
 
   .pl-lg-1,
-  .px-lg-1 {
+.px-lg-1 {
     padding-left: 0.5rem !important;
   }
 
@@ -5742,22 +5741,22 @@ button.bg-orange:focus {
   }
 
   .pt-lg-2,
-  .py-lg-2 {
+.py-lg-2 {
     padding-top: 1rem !important;
   }
 
   .pr-lg-2,
-  .px-lg-2 {
+.px-lg-2 {
     padding-right: 1rem !important;
   }
 
   .pb-lg-2,
-  .py-lg-2 {
+.py-lg-2 {
     padding-bottom: 1rem !important;
   }
 
   .pl-lg-2,
-  .px-lg-2 {
+.px-lg-2 {
     padding-left: 1rem !important;
   }
 
@@ -5766,22 +5765,22 @@ button.bg-orange:focus {
   }
 
   .pt-lg-3,
-  .py-lg-3 {
+.py-lg-3 {
     padding-top: 2rem !important;
   }
 
   .pr-lg-3,
-  .px-lg-3 {
+.px-lg-3 {
     padding-right: 2rem !important;
   }
 
   .pb-lg-3,
-  .py-lg-3 {
+.py-lg-3 {
     padding-bottom: 2rem !important;
   }
 
   .pl-lg-3,
-  .px-lg-3 {
+.px-lg-3 {
     padding-left: 2rem !important;
   }
 
@@ -5790,22 +5789,22 @@ button.bg-orange:focus {
   }
 
   .pt-lg-4,
-  .py-lg-4 {
+.py-lg-4 {
     padding-top: 3rem !important;
   }
 
   .pr-lg-4,
-  .px-lg-4 {
+.px-lg-4 {
     padding-right: 3rem !important;
   }
 
   .pb-lg-4,
-  .py-lg-4 {
+.py-lg-4 {
     padding-bottom: 3rem !important;
   }
 
   .pl-lg-4,
-  .px-lg-4 {
+.px-lg-4 {
     padding-left: 3rem !important;
   }
 
@@ -5814,22 +5813,22 @@ button.bg-orange:focus {
   }
 
   .pt-lg-5,
-  .py-lg-5 {
+.py-lg-5 {
     padding-top: 6rem !important;
   }
 
   .pr-lg-5,
-  .px-lg-5 {
+.px-lg-5 {
     padding-right: 6rem !important;
   }
 
   .pb-lg-5,
-  .py-lg-5 {
+.py-lg-5 {
     padding-bottom: 6rem !important;
   }
 
   .pl-lg-5,
-  .px-lg-5 {
+.px-lg-5 {
     padding-left: 6rem !important;
   }
 
@@ -5838,22 +5837,22 @@ button.bg-orange:focus {
   }
 
   .mt-lg-auto,
-  .my-lg-auto {
+.my-lg-auto {
     margin-top: auto !important;
   }
 
   .mr-lg-auto,
-  .mx-lg-auto {
+.mx-lg-auto {
     margin-right: auto !important;
   }
 
   .mb-lg-auto,
-  .my-lg-auto {
+.my-lg-auto {
     margin-bottom: auto !important;
   }
 
   .ml-lg-auto,
-  .mx-lg-auto {
+.mx-lg-auto {
     margin-left: auto !important;
   }
 }
@@ -5863,22 +5862,22 @@ button.bg-orange:focus {
   }
 
   .mt-xl-0,
-  .my-xl-0 {
+.my-xl-0 {
     margin-top: 0 !important;
   }
 
   .mr-xl-0,
-  .mx-xl-0 {
+.mx-xl-0 {
     margin-right: 0 !important;
   }
 
   .mb-xl-0,
-  .my-xl-0 {
+.my-xl-0 {
     margin-bottom: 0 !important;
   }
 
   .ml-xl-0,
-  .mx-xl-0 {
+.mx-xl-0 {
     margin-left: 0 !important;
   }
 
@@ -5887,22 +5886,22 @@ button.bg-orange:focus {
   }
 
   .mt-xl-1,
-  .my-xl-1 {
+.my-xl-1 {
     margin-top: 0.5rem !important;
   }
 
   .mr-xl-1,
-  .mx-xl-1 {
+.mx-xl-1 {
     margin-right: 0.5rem !important;
   }
 
   .mb-xl-1,
-  .my-xl-1 {
+.my-xl-1 {
     margin-bottom: 0.5rem !important;
   }
 
   .ml-xl-1,
-  .mx-xl-1 {
+.mx-xl-1 {
     margin-left: 0.5rem !important;
   }
 
@@ -5911,22 +5910,22 @@ button.bg-orange:focus {
   }
 
   .mt-xl-2,
-  .my-xl-2 {
+.my-xl-2 {
     margin-top: 1rem !important;
   }
 
   .mr-xl-2,
-  .mx-xl-2 {
+.mx-xl-2 {
     margin-right: 1rem !important;
   }
 
   .mb-xl-2,
-  .my-xl-2 {
+.my-xl-2 {
     margin-bottom: 1rem !important;
   }
 
   .ml-xl-2,
-  .mx-xl-2 {
+.mx-xl-2 {
     margin-left: 1rem !important;
   }
 
@@ -5935,22 +5934,22 @@ button.bg-orange:focus {
   }
 
   .mt-xl-3,
-  .my-xl-3 {
+.my-xl-3 {
     margin-top: 2rem !important;
   }
 
   .mr-xl-3,
-  .mx-xl-3 {
+.mx-xl-3 {
     margin-right: 2rem !important;
   }
 
   .mb-xl-3,
-  .my-xl-3 {
+.my-xl-3 {
     margin-bottom: 2rem !important;
   }
 
   .ml-xl-3,
-  .mx-xl-3 {
+.mx-xl-3 {
     margin-left: 2rem !important;
   }
 
@@ -5959,22 +5958,22 @@ button.bg-orange:focus {
   }
 
   .mt-xl-4,
-  .my-xl-4 {
+.my-xl-4 {
     margin-top: 3rem !important;
   }
 
   .mr-xl-4,
-  .mx-xl-4 {
+.mx-xl-4 {
     margin-right: 3rem !important;
   }
 
   .mb-xl-4,
-  .my-xl-4 {
+.my-xl-4 {
     margin-bottom: 3rem !important;
   }
 
   .ml-xl-4,
-  .mx-xl-4 {
+.mx-xl-4 {
     margin-left: 3rem !important;
   }
 
@@ -5983,22 +5982,22 @@ button.bg-orange:focus {
   }
 
   .mt-xl-5,
-  .my-xl-5 {
+.my-xl-5 {
     margin-top: 6rem !important;
   }
 
   .mr-xl-5,
-  .mx-xl-5 {
+.mx-xl-5 {
     margin-right: 6rem !important;
   }
 
   .mb-xl-5,
-  .my-xl-5 {
+.my-xl-5 {
     margin-bottom: 6rem !important;
   }
 
   .ml-xl-5,
-  .mx-xl-5 {
+.mx-xl-5 {
     margin-left: 6rem !important;
   }
 
@@ -6007,22 +6006,22 @@ button.bg-orange:focus {
   }
 
   .pt-xl-0,
-  .py-xl-0 {
+.py-xl-0 {
     padding-top: 0 !important;
   }
 
   .pr-xl-0,
-  .px-xl-0 {
+.px-xl-0 {
     padding-right: 0 !important;
   }
 
   .pb-xl-0,
-  .py-xl-0 {
+.py-xl-0 {
     padding-bottom: 0 !important;
   }
 
   .pl-xl-0,
-  .px-xl-0 {
+.px-xl-0 {
     padding-left: 0 !important;
   }
 
@@ -6031,22 +6030,22 @@ button.bg-orange:focus {
   }
 
   .pt-xl-1,
-  .py-xl-1 {
+.py-xl-1 {
     padding-top: 0.5rem !important;
   }
 
   .pr-xl-1,
-  .px-xl-1 {
+.px-xl-1 {
     padding-right: 0.5rem !important;
   }
 
   .pb-xl-1,
-  .py-xl-1 {
+.py-xl-1 {
     padding-bottom: 0.5rem !important;
   }
 
   .pl-xl-1,
-  .px-xl-1 {
+.px-xl-1 {
     padding-left: 0.5rem !important;
   }
 
@@ -6055,22 +6054,22 @@ button.bg-orange:focus {
   }
 
   .pt-xl-2,
-  .py-xl-2 {
+.py-xl-2 {
     padding-top: 1rem !important;
   }
 
   .pr-xl-2,
-  .px-xl-2 {
+.px-xl-2 {
     padding-right: 1rem !important;
   }
 
   .pb-xl-2,
-  .py-xl-2 {
+.py-xl-2 {
     padding-bottom: 1rem !important;
   }
 
   .pl-xl-2,
-  .px-xl-2 {
+.px-xl-2 {
     padding-left: 1rem !important;
   }
 
@@ -6079,22 +6078,22 @@ button.bg-orange:focus {
   }
 
   .pt-xl-3,
-  .py-xl-3 {
+.py-xl-3 {
     padding-top: 2rem !important;
   }
 
   .pr-xl-3,
-  .px-xl-3 {
+.px-xl-3 {
     padding-right: 2rem !important;
   }
 
   .pb-xl-3,
-  .py-xl-3 {
+.py-xl-3 {
     padding-bottom: 2rem !important;
   }
 
   .pl-xl-3,
-  .px-xl-3 {
+.px-xl-3 {
     padding-left: 2rem !important;
   }
 
@@ -6103,22 +6102,22 @@ button.bg-orange:focus {
   }
 
   .pt-xl-4,
-  .py-xl-4 {
+.py-xl-4 {
     padding-top: 3rem !important;
   }
 
   .pr-xl-4,
-  .px-xl-4 {
+.px-xl-4 {
     padding-right: 3rem !important;
   }
 
   .pb-xl-4,
-  .py-xl-4 {
+.py-xl-4 {
     padding-bottom: 3rem !important;
   }
 
   .pl-xl-4,
-  .px-xl-4 {
+.px-xl-4 {
     padding-left: 3rem !important;
   }
 
@@ -6127,22 +6126,22 @@ button.bg-orange:focus {
   }
 
   .pt-xl-5,
-  .py-xl-5 {
+.py-xl-5 {
     padding-top: 6rem !important;
   }
 
   .pr-xl-5,
-  .px-xl-5 {
+.px-xl-5 {
     padding-right: 6rem !important;
   }
 
   .pb-xl-5,
-  .py-xl-5 {
+.py-xl-5 {
     padding-bottom: 6rem !important;
   }
 
   .pl-xl-5,
-  .px-xl-5 {
+.px-xl-5 {
     padding-left: 6rem !important;
   }
 
@@ -6151,22 +6150,22 @@ button.bg-orange:focus {
   }
 
   .mt-xl-auto,
-  .my-xl-auto {
+.my-xl-auto {
     margin-top: auto !important;
   }
 
   .mr-xl-auto,
-  .mx-xl-auto {
+.mx-xl-auto {
     margin-right: auto !important;
   }
 
   .mb-xl-auto,
-  .my-xl-auto {
+.my-xl-auto {
     margin-bottom: auto !important;
   }
 
   .ml-xl-auto,
-  .mx-xl-auto {
+.mx-xl-auto {
     margin-left: auto !important;
   }
 }
@@ -6302,7 +6301,7 @@ button.bg-orange:focus {
   vertical-align: 0;
 }
 
-.dropdown-menu[x-placement^="top"], .dropdown-menu[x-placement^="right"], .dropdown-menu[x-placement^="bottom"], .dropdown-menu[x-placement^="left"] {
+.dropdown-menu[x-placement^=top], .dropdown-menu[x-placement^=right], .dropdown-menu[x-placement^=bottom], .dropdown-menu[x-placement^=left] {
   right: auto;
   bottom: auto;
 }
@@ -6378,15 +6377,15 @@ button.bg-orange:focus {
 .fa-lg {
   font-size: 1.3333333333em;
   line-height: 0.75em;
-  vertical-align: -.0667em;
+  vertical-align: -0.0667em;
 }
 
 .fa-xs {
-  font-size: .75em;
+  font-size: 0.75em;
 }
 
 .fa-sm {
-  font-size: .875em;
+  font-size: 0.875em;
 }
 
 .fa-1x {
@@ -6439,7 +6438,7 @@ button.bg-orange:focus {
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  */
 @font-face {
-  font-family: 'Font Awesome 5 Free';
+  font-family: "Font Awesome 5 Free";
   font-style: normal;
   font-weight: 900;
   font-display: block;
@@ -6448,7 +6447,7 @@ button.bg-orange:focus {
 }
 .fa,
 .fas {
-  font-family: 'Font Awesome 5 Free';
+  font-family: "Font Awesome 5 Free";
   font-weight: 900;
 }
 
@@ -6457,7 +6456,7 @@ button.bg-orange:focus {
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  */
 @font-face {
-  font-family: 'Font Awesome 5 Brands';
+  font-family: "Font Awesome 5 Brands";
   font-style: normal;
   font-weight: 400;
   font-display: block;
@@ -6465,68 +6464,68 @@ button.bg-orange:focus {
   src: url("./vendor/fa/webfonts/fa-brands-400.eot?#iefix") format("embedded-opentype"), url("./vendor/fa/webfonts/fa-brands-400.woff2") format("woff2"), url("./vendor/fa/webfonts/fa-brands-400.woff") format("woff"), url("./vendor/fa/webfonts/fa-brands-400.ttf") format("truetype"), url("./vendor/fa/webfonts/fa-brands-400.svg#fontawesome") format("svg");
 }
 .fab {
-  font-family: 'Font Awesome 5 Brands';
+  font-family: "Font Awesome 5 Brands";
   font-weight: 400;
 }
 
 .fa-user:before {
-  content: "";
+  content: "\f007";
 }
 
 .fa-search:before {
-  content: "";
+  content: "\f002";
 }
 
 .fa-calendar-alt:before {
-  content: "";
+  content: "\f073";
 }
 
 .fa-tag:before {
-  content: "";
+  content: "\f02b";
 }
 
 .fa-comments:before {
-  content: "";
+  content: "\f086";
 }
 
 .fa-home:before {
-  content: "";
+  content: "\f015";
 }
 
 .fa-exclamation-circle:before {
-  content: "";
+  content: "\f06a";
 }
 
 .fa-times-circle:before {
-  content: "";
+  content: "\f057";
 }
 
 .fa-check-circle:before {
-  content: "";
+  content: "\f058";
 }
 
 .fa-question-circle:before {
-  content: "";
+  content: "\f059";
 }
 
 .fa-lightbulb:before {
-  content: "";
+  content: "\f0eb";
 }
 
 .fa-bars:before {
-  content: "";
+  content: "\f0c9";
 }
 
 .fa-plus-circle:before {
-  content: "";
+  content: "\f055";
 }
 
 .fa-facebook-f:before {
-  content: "";
+  content: "\f39e";
 }
 
 .fa-twitter:before {
-  content: "";
+  content: "\f099";
 }
 
 #navigation {
@@ -6773,7 +6772,7 @@ button.bg-orange:focus {
   margin-top: -1rem;
 }
 .section-inner::after {
-  content: '';
+  content: "";
   display: block;
   clear: both;
 }
@@ -6788,7 +6787,7 @@ button.bg-orange:focus {
   text-align: center;
 }
 .claim::after {
-  content: '';
+  content: "";
   display: block;
   width: 100%;
   height: 150px;
@@ -6826,7 +6825,7 @@ button.bg-orange:focus {
 }
 @media (min-width: 992px) {
   .claim,
-  .claim h1 {
+.claim h1 {
     font-size: 1.875rem;
   }
 }
@@ -6892,25 +6891,25 @@ button.bg-orange:focus {
   display: inline-block;
   width: 0;
   height: 0;
-  margin-left: .6em;
-  margin-right: .6em;
+  margin-left: 0.6em;
+  margin-right: 0.6em;
   margin-bottom: 8px;
-  border-right: .3em solid transparent;
-  border-bottom-width: .7em;
+  border-right: 0.3em solid transparent;
+  border-bottom-width: 0.7em;
   border-bottom-style: solid;
-  border-left: .3em solid transparent;
+  border-left: 0.3em solid transparent;
   font-size: 8px;
 }
 .star::before, .star::after {
-  content: '';
+  content: "";
   position: absolute;
-  top: .6em;
+  top: 0.6em;
   left: -1em;
   display: block;
   width: 0;
   height: 0;
   border-right: 1em solid transparent;
-  border-bottom-width: .7em;
+  border-bottom-width: 0.7em;
   border-bottom-style: solid;
   border-left: 1em solid transparent;
   transform: rotate(-35deg);
@@ -7264,10 +7263,10 @@ body.overlay-visible .overlay {
   font-size: 1rem;
 }
 .has-icon i:first-child {
-  margin-right: .5ex;
+  margin-right: 0.5ex;
 }
 .has-icon i:last-child {
-  margin-left: .5ex;
+  margin-left: 0.5ex;
 }
 
 a.has-icon {
@@ -7482,7 +7481,7 @@ article .entry-more {
   margin-top: 20px;
 }
 
-.comment-form label:not([for="wp-comment-cookies-consent"]) {
+.comment-form label:not([for=wp-comment-cookies-consent]) {
   display: block;
 }
 
@@ -7512,7 +7511,7 @@ article .entry-more {
   display: flex;
 }
 .alert, .alert.alert-dismissible {
-  padding: .75rem 1.25rem;
+  padding: 0.75rem 1.25rem;
 }
 .alert .row {
   width: 100%;
@@ -7564,7 +7563,7 @@ article .entry-more {
   flex-wrap: nowrap;
   min-width: 0;
 }
-.cta form input[type="text"] {
+.cta form input[type=text] {
   background: #fff;
   color: #1f1f1f;
   border: 1px solid transparent;
@@ -7580,7 +7579,7 @@ article .entry-more {
   text-transform: none;
   width: auto;
 }
-.cta form button[type="submit"] {
+.cta form button[type=submit] {
   background: #f7a12b;
   color: #fff;
   border: 1px solid #f7a12b;
@@ -7597,7 +7596,7 @@ article .entry-more {
   padding: 0 10px;
   outline: none;
 }
-.cta form button[type="submit"] strong {
+.cta form button[type=submit] strong {
   font-size: 18px;
 }
 
@@ -7650,7 +7649,7 @@ h1:first-child, h2:first-child, h3:first-child, h4:first-child, h5:first-child, 
 
 @media (max-width: 767px) {
   h1,
-  .h1 {
+.h1 {
     font-size: 2.0704rem;
     margin-top: 1rem;
   }
@@ -7658,30 +7657,30 @@ h1:first-child, h2:first-child, h3:first-child, h4:first-child, h5:first-child, 
 
 @media (max-width: 767px) {
   h2,
-  .h2 {
+.h2 {
     font-size: 1.5528rem;
   }
 }
 
 @media (max-width: 767px) {
   h3,
-  .h3 {
+.h3 {
     font-size: 1.3239rem;
   }
 }
 
 @media (max-width: 767px) {
   h4,
-  .h4 {
+.h4 {
     font-size: 1.0962rem;
   }
 }
 
 @media (max-width: 767px) {
   h5,
-  .h5,
-  h6,
-  .h6 {
+.h5,
+h6,
+.h6 {
     font-size: 1rem;
   }
 }
@@ -7782,22 +7781,22 @@ blockquote:before, blockquote:after {
   height: 30px;
 }
 blockquote:before {
-  content: "\201C";
+  content: "“";
   left: 15px;
   top: 15px;
   text-align: left;
 }
 blockquote:after {
-  content: "\201D";
+  content: "”";
   right: 30px;
   bottom: 15px;
   text-align: right;
 }
 
-a[data-toggle="tooltip"] {
+a[data-toggle=tooltip] {
   border-bottom: 1px dotted #6c757d;
 }
-a[data-toggle="tooltip"]:hover {
+a[data-toggle=tooltip]:hover {
   text-decoration: none;
   border-bottom: none;
 }
@@ -7810,7 +7809,7 @@ a[data-toggle="tooltip"]:hover {
   display: inline-block;
 }
 .social-share > li:not(:last-child) {
-  margin-right: .5rem;
+  margin-right: 0.5rem;
 }
 
 .social-share-link {
@@ -7826,7 +7825,7 @@ a[data-toggle="tooltip"]:hover {
 }
 .social-share-link:hover, .social-share-link:focus {
   color: #fff;
-  opacity: .8;
+  opacity: 0.8;
 }
 
 .social-share-link-facebook {
@@ -7836,5 +7835,3 @@ a[data-toggle="tooltip"]:hover {
 .social-share-link-twitter {
   background-color: #1DA1F2;
 }
-
-/*# sourceMappingURL=shoptet.css.map */

--- a/shoptet/_common.scss
+++ b/shoptet/_common.scss
@@ -74,9 +74,9 @@ th {
 
 .tags {
     > div {
-        margin-bottom: round(-$grid-gutter-width / 4);
+        margin-bottom: round(-$grid-gutter-width * 0.25);
         .btn {
-            margin: 0 round($grid-gutter-width / 4) round($grid-gutter-width / 4) 0;
+            margin: 0 round($grid-gutter-width * 0.25) round($grid-gutter-width * 0.25) 0;
         }
     }
     h3 {
@@ -98,7 +98,7 @@ th {
 }
 
 h3 + h3 {
-    margin-top: round(-$headings-margin-bottom / 2);
+    margin-top: round(-$headings-margin-bottom * 0.5);
 }
 
 .image-caption {
@@ -106,8 +106,8 @@ h3 + h3 {
     > img {
         float: left;
         width: $image-caption-width;
-        margin-right: round($grid-gutter-width / 2);
-        margin-bottom: round($grid-gutter-width / 2);
+        margin-right: round($grid-gutter-width * 0.5);
+        margin-bottom: round($grid-gutter-width * 0.5);
         border-radius: $border-radius;
     }
 }
@@ -129,7 +129,7 @@ blockquote {
     margin: $grid-gutter-width auto;
     font-style: italic;
     color: $gray-dark;
-    padding: $grid-gutter-width round($grid-gutter-width * 2) round($grid-gutter-width / 2);
+    padding: $grid-gutter-width round($grid-gutter-width * 2) round($grid-gutter-width * 0.5);
     border-left: 8px solid $shoptet-green;
     position: relative;
     background: $gray-lighter;
@@ -147,14 +147,14 @@ blockquote {
     }
     &:before {
         content: "\201C";
-        left: round($grid-gutter-width / 2);
-        top: round($grid-gutter-width / 2);
+        left: round($grid-gutter-width * 0.5);
+        top: round($grid-gutter-width * 0.5);
         text-align: left;
     }
     &:after{
         content: "\201D";
         right: $grid-gutter-width;
-        bottom: round($grid-gutter-width / 2);
+        bottom: round($grid-gutter-width * 0.5);
         text-align: right;
     }
 }

--- a/shoptet/_content-box.scss
+++ b/shoptet/_content-box.scss
@@ -60,8 +60,8 @@
     padding-right: $content-box-padding-x;
     &.content-box-caption {
         position: relative;
-        padding-top: $content-box-padding-y / 2;
-        padding-bottom: $content-box-padding-y / 2;
+        padding-top: $content-box-padding-y * 0.5;
+        padding-bottom: $content-box-padding-y * 0.5;
         text-align: center;
     }
     + .content-box-inner {

--- a/shoptet/_halfs.scss
+++ b/shoptet/_halfs.scss
@@ -17,19 +17,19 @@
         width: 50%;
         .aligned-right &:first-child {
             order: 2;
-            padding-left: $grid-gutter-width / 2;
+            padding-left: $grid-gutter-width * 0.5;
         }
         .aligned-right &:last-child {
             order: 1;
-            padding-right: $grid-gutter-width / 2;
+            padding-right: $grid-gutter-width * 0.5;
         }
         .aligned-left &:first-child {
             order: 1;
-            padding-right: $grid-gutter-width / 2;
+            padding-right: $grid-gutter-width * 0.5;
         }
         .aligned-left &:last-child {
             order: 2;
-            padding-left: $grid-gutter-width / 2;
+            padding-left: $grid-gutter-width * 0.5;
         }
     }
     @media (max-width: map-get($grid-breakpoints, 'md') - 1) {

--- a/shoptet/_header.scss
+++ b/shoptet/_header.scss
@@ -29,9 +29,9 @@
         }
     }
     @media (max-width: map-get($grid-breakpoints, 'lg') - 1) {
-        padding-bottom: $header-padding-y - round($spacer / 2);
+        padding-bottom: $header-padding-y - round($spacer * 0.5);
         > div {
-            padding-bottom: round($spacer / 2);
+            padding-bottom: round($spacer * 0.5);
             text-align: center;
             margin: auto;
             width: 100%;
@@ -53,19 +53,19 @@
         vertical-align: middle;
     }
     @media (min-width: map-get($grid-breakpoints, 'lg')) {
-        padding-right: round($grid-gutter-width / 2);
+        padding-right: round($grid-gutter-width * 0.5);
     }
 }
 
 .header-login {
     .btn-add {
-        margin-right: round($grid-gutter-width / 2);
+        margin-right: round($grid-gutter-width * 0.5);
     }
     @media (max-width: map-get($grid-breakpoints, 'sm') - 1) {
         .btn-add {
             display: block;
             margin-right: 0;
-            margin-bottom: round($spacer / 2);
+            margin-bottom: round($spacer * 0.5);
         }
     }
 }

--- a/shoptet/_loader.scss
+++ b/shoptet/_loader.scss
@@ -5,8 +5,8 @@
     display: block;
     width: $loader-size;
     height: $loader-size;
-    margin-top: -(round($loader-size / 2));
-    margin-left: -(round($loader-size / 2));
+    margin-top: -(round($loader-size * 0.5));
+    margin-left: -(round($loader-size * 0.5));
     border-style: solid;
     border-width: $loader-border-width;
     border-color: $primary;

--- a/shoptet/_navigation.scss
+++ b/shoptet/_navigation.scss
@@ -37,7 +37,7 @@
         }
     }
     .caret {
-        padding: $navigation-item-padding-y $navigation-item-padding-x $navigation-item-padding-y ($navigation-item-padding-x / 2);
+        padding: $navigation-item-padding-y $navigation-item-padding-x $navigation-item-padding-y ($navigation-item-padding-x * 0.5);
         display: inline-block;
         cursor: pointer;
     }
@@ -45,7 +45,7 @@
         display: block;
     }
     &.has-dropdown > a {
-        padding-right: $navigation-item-padding-x / 2;
+        padding-right: $navigation-item-padding-x * 0.5;
     }
     ul {
         padding: 0;
@@ -53,7 +53,7 @@
         li:first-child,
         li:last-child {
             a {
-                padding: $navigation-item-padding-y / 2 $navigation-item-padding-x;
+                padding: $navigation-item-padding-y * 0.5 $navigation-item-padding-x;
                 display: block;
                 &.first {
                     padding-top: $navigation-item-padding-y;
@@ -87,7 +87,7 @@
 
     @media (max-width: map-get($grid-breakpoints, 'sm') - 1) {
         .container > & {
-            margin-right: -($grid-gutter-width / 2);
+            margin-right: -($grid-gutter-width * 0.5);
         }
     }
 

--- a/shoptet/_tooltip.scss
+++ b/shoptet/_tooltip.scss
@@ -1,10 +1,10 @@
 .tooltip {
     div {
-        margin-bottom: round($spacer / 2);
+        margin-bottom: round($spacer * 0.5);
         text-align: left;
     }
     ul {
-        padding-left: round($spacer / 2);
+        padding-left: round($spacer * 0.5);
         text-align: left;
     }
 }

--- a/shoptet/_variables-bootstrap.scss
+++ b/shoptet/_variables-bootstrap.scss
@@ -29,7 +29,7 @@ $theme-colors: (
 $font-size-base: 1rem;
 $font-size-lg: $font-size-base * 1.2;
 $font-family-sans-serif: 'Source Sans Pro', sans-serif;
-$headings-margin-bottom: $spacer / 2;
+$headings-margin-bottom: $spacer * 0.5;
 $headings-font-family: 'Libre Franklin', sans-serif;
 $headings-font-weight: 300;
 $headings-color: inherit;

--- a/shoptet/_wp.scss
+++ b/shoptet/_wp.scss
@@ -116,7 +116,7 @@ article {
 .post-navigation {
     > div {
         + div {
-            padding-top: $spacer / 2;
+            padding-top: $spacer * 0.5;
         }
     }
     .btn {

--- a/vendor/bs/scss/_card.scss
+++ b/vendor/bs/scss/_card.scss
@@ -43,7 +43,7 @@
 }
 
 .card-subtitle {
-  margin-top: -($card-spacer-y / 2);
+  margin-top: -($card-spacer-y * 0.5);
   margin-bottom: 0;
 }
 
@@ -98,15 +98,15 @@
 //
 
 .card-header-tabs {
-  margin-right: -($card-spacer-x / 2);
+  margin-right: -($card-spacer-x * 0.5);
   margin-bottom: -$card-spacer-y;
-  margin-left: -($card-spacer-x / 2);
+  margin-left: -($card-spacer-x * 0.5);
   border-bottom: 0;
 }
 
 .card-header-pills {
-  margin-right: -($card-spacer-x / 2);
-  margin-left: -($card-spacer-x / 2);
+  margin-right: -($card-spacer-x * 0.5);
+  margin-left: -($card-spacer-x * 0.5);
 }
 
 // Card image

--- a/vendor/bs/scss/_carousel.scss
+++ b/vendor/bs/scss/_carousel.scss
@@ -225,9 +225,9 @@
 
 .carousel-caption {
   position: absolute;
-  right: ((100% - $carousel-caption-width) / 2);
+  right: ((100% - $carousel-caption-width) * 0.5);
   bottom: 20px;
-  left: ((100% - $carousel-caption-width) / 2);
+  left: ((100% - $carousel-caption-width) * 0.5);
   z-index: 10;
   padding-top: 20px;
   padding-bottom: 20px;

--- a/vendor/bs/scss/_custom-forms.scss
+++ b/vendor/bs/scss/_custom-forms.scss
@@ -63,7 +63,7 @@
   // Background-color and (when enabled) gradient
   &::before {
     position: absolute;
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: (($line-height-base - $custom-control-indicator-size) * 0.5);
     left: -$custom-control-gutter;
     display: block;
     width: $custom-control-indicator-size;
@@ -78,7 +78,7 @@
   // Foreground (icon)
   &::after {
     position: absolute;
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: (($line-height-base - $custom-control-indicator-size) * 0.5);
     left: -$custom-control-gutter;
     display: block;
     width: $custom-control-indicator-size;

--- a/vendor/bs/scss/_functions.scss
+++ b/vendor/bs/scss/_functions.scss
@@ -54,7 +54,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) * 0.001;
 
   @if ($yiq >= $yiq-contrasted-threshold) {
     @return $yiq-text-dark;

--- a/vendor/bs/scss/_images.scss
+++ b/vendor/bs/scss/_images.scss
@@ -32,7 +32,7 @@
 }
 
 .figure-img {
-  margin-bottom: ($spacer / 2);
+  margin-bottom: ($spacer * 0.5);
   line-height: 1;
 }
 

--- a/vendor/bs/scss/_jumbotron.scss
+++ b/vendor/bs/scss/_jumbotron.scss
@@ -1,5 +1,5 @@
 .jumbotron {
-  padding: $jumbotron-padding ($jumbotron-padding / 2);
+  padding: $jumbotron-padding ($jumbotron-padding * 0.5);
   margin-bottom: $jumbotron-padding;
   background-color: $jumbotron-bg;
   @include border-radius($border-radius-lg);

--- a/vendor/bs/scss/_popover.scss
+++ b/vendor/bs/scss/_popover.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .popover {
   position: absolute;
   top: 0;
@@ -44,7 +46,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: $popover-arrow-height ($popover-arrow-width * 0.5) 0;
   }
 
   .arrow::before {
@@ -70,7 +72,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: ($popover-arrow-width * 0.5) $popover-arrow-height ($popover-arrow-width * 0.5) 0;
   }
 
   .arrow::before {
@@ -93,7 +95,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: 0 ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2);
+    border-width: 0 ($popover-arrow-width * 0.5) $popover-arrow-height ($popover-arrow-width * 0.5);
   }
 
   .arrow::before {
@@ -113,7 +115,7 @@
     left: 50%;
     display: block;
     width: $popover-arrow-width;
-    margin-left: ($popover-arrow-width / -2);
+    margin-left: math.div($popover-arrow-width, -2);
     content: "";
     border-bottom: $popover-border-width solid $popover-header-bg;
   }
@@ -131,7 +133,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) 0 ($popover-arrow-width / 2) $popover-arrow-height;
+    border-width: ($popover-arrow-width * 0.5) 0 ($popover-arrow-width * 0.5) $popover-arrow-height;
   }
 
   .arrow::before {

--- a/vendor/bs/scss/_tooltip.scss
+++ b/vendor/bs/scss/_tooltip.scss
@@ -37,7 +37,7 @@
 
     &::before {
       top: 0;
-      border-width: $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+      border-width: $tooltip-arrow-height ($tooltip-arrow-width * 0.5) 0;
       border-top-color: $tooltip-arrow-color;
     }
   }
@@ -53,7 +53,7 @@
 
     &::before {
       right: 0;
-      border-width: ($tooltip-arrow-width / 2) $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+      border-width: ($tooltip-arrow-width * 0.5) $tooltip-arrow-height ($tooltip-arrow-width * 0.5) 0;
       border-right-color: $tooltip-arrow-color;
     }
   }
@@ -67,7 +67,7 @@
 
     &::before {
       bottom: 0;
-      border-width: 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+      border-width: 0 ($tooltip-arrow-width * 0.5) $tooltip-arrow-height;
       border-bottom-color: $tooltip-arrow-color;
     }
   }
@@ -83,7 +83,7 @@
 
     &::before {
       left: 0;
-      border-width: ($tooltip-arrow-width / 2) 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+      border-width: ($tooltip-arrow-width * 0.5) 0 ($tooltip-arrow-width * 0.5) $tooltip-arrow-height;
       border-left-color: $tooltip-arrow-color;
     }
   }

--- a/vendor/bs/scss/_variables.scss
+++ b/vendor/bs/scss/_variables.scss
@@ -254,7 +254,7 @@ $h4-font-size:                $font-size-base * 1.5 !default;
 $h5-font-size:                $font-size-base * 1.25 !default;
 $h6-font-size:                $font-size-base !default;
 
-$headings-margin-bottom:      ($spacer / 2) !default;
+$headings-margin-bottom:      ($spacer * 0.5) !default;
 $headings-font-family:        inherit !default;
 $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
@@ -617,11 +617,11 @@ $nav-pills-link-active-color:       $component-active-color !default;
 $nav-pills-link-active-bg:          $component-active-bg !default;
 
 $nav-divider-color:                 $gray-200 !default;
-$nav-divider-margin-y:              ($spacer / 2) !default;
+$nav-divider-margin-y:              ($spacer * 0.5) !default;
 
 // Navbar
 
-$navbar-padding-y:                  ($spacer / 2) !default;
+$navbar-padding-y:                  ($spacer * 0.5) !default;
 $navbar-padding-x:                  $spacer !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;
@@ -630,7 +630,7 @@ $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height:                   ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;
 $navbar-brand-height:               $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) / 2 !default;
+$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) * 0.5 !default;
 
 $navbar-toggler-padding-y:          .25rem !default;
 $navbar-toggler-padding-x:          .75rem !default;
@@ -701,7 +701,7 @@ $card-bg:                           $white !default;
 
 $card-img-overlay-padding:          1.25rem !default;
 
-$card-group-margin:                 ($grid-gutter-width / 2) !default;
+$card-group-margin:                 ($grid-gutter-width * 0.5) !default;
 $card-deck-margin:                  $card-group-margin !default;
 
 $card-columns-count:                3 !default;

--- a/vendor/bs/scss/mixins/_grid-framework.scss
+++ b/vendor/bs/scss/mixins/_grid-framework.scss
@@ -9,8 +9,8 @@
     position: relative;
     width: 100%;
     min-height: 1px; // Prevent columns from collapsing when empty
-    padding-right: ($gutter / 2);
-    padding-left: ($gutter / 2);
+    padding-right: ($gutter * 0.5);
+    padding-left: ($gutter * 0.5);
   }
 
   @each $breakpoint in map-keys($breakpoints) {

--- a/vendor/bs/scss/mixins/_grid.scss
+++ b/vendor/bs/scss/mixins/_grid.scss
@@ -2,10 +2,12 @@
 //
 // Generate semantic grid columns with these mixins.
 
+@use "sass:math";
+
 @mixin make-container() {
   width: 100%;
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: ($grid-gutter-width * 0.5);
+  padding-left: ($grid-gutter-width * 0.5);
   margin-right: auto;
   margin-left: auto;
 }
@@ -23,8 +25,8 @@
 @mixin make-row() {
   display: flex;
   flex-wrap: wrap;
-  margin-right: ($grid-gutter-width / -2);
-  margin-left: ($grid-gutter-width / -2);
+  margin-right: math.div($grid-gutter-width, -2);
+  margin-left: math.div($grid-gutter-width, -2);
 }
 
 @mixin make-col-ready() {
@@ -34,19 +36,19 @@
   // later on to override this initial width.
   width: 100%;
   min-height: 1px; // Prevent collapsing
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: ($grid-gutter-width * 0.5);
+  padding-left: ($grid-gutter-width * 0.5);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
-  flex: 0 0 percentage($size / $columns);
+  flex: 0 0 percentage(math.div($size, $columns));
   // Add a `max-width` to ensure content within each column does not blow out
   // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
   // do not appear to require this.
-  max-width: percentage($size / $columns);
+  max-width: percentage(math.div($size, $columns));
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
-  $num: $size / $columns;
+  $num: math.div($size, $columns);
   margin-left: if($num == 0, 0, percentage($num));
 }

--- a/vendor/bs/scss/utilities/_embed.scss
+++ b/vendor/bs/scss/utilities/_embed.scss
@@ -1,5 +1,7 @@
 // Credit: Nicolas Gallagher and SUIT CSS.
 
+@use "sass:math";
+
 .embed-responsive {
   position: relative;
   display: block;
@@ -29,24 +31,24 @@
 
 .embed-responsive-21by9 {
   &::before {
-    padding-top: percentage(9 / 21);
+    padding-top: percentage(math.div(9, 21));
   }
 }
 
 .embed-responsive-16by9 {
   &::before {
-    padding-top: percentage(9 / 16);
+    padding-top: percentage(math.div(9, 16));
   }
 }
 
 .embed-responsive-4by3 {
   &::before {
-    padding-top: percentage(3 / 4);
+    padding-top: percentage(3 * 0.25);
   }
 }
 
 .embed-responsive-1by1 {
   &::before {
-    padding-top: percentage(1 / 1);
+    padding-top: percentage(math.div(1, 1));
   }
 }

--- a/vendor/fa/scss/_larger.scss
+++ b/vendor/fa/scss/_larger.scss
@@ -2,9 +2,11 @@
 // -------------------------
 
 // makes the font 33% larger relative to the icon container
+@use "sass:math";
+
 .#{$fa-css-prefix}-lg {
-  font-size: (4em / 3);
-  line-height: (3em / 4);
+  font-size: math.div(4em, 3);
+  line-height: (3em * 0.25);
   vertical-align: -.0667em;
 }
 

--- a/vendor/fa/scss/_list.scss
+++ b/vendor/fa/scss/_list.scss
@@ -3,7 +3,7 @@
 
 .#{$fa-css-prefix}-ul {
   list-style-type: none;
-  margin-left: $fa-li-width * 5/4;
+  margin-left: $fa-li-width * 5*0.25;
   padding-left: 0;
 
   > li { position: relative; }

--- a/vendor/fa/scss/_variables.scss
+++ b/vendor/fa/scss/_variables.scss
@@ -1,6 +1,8 @@
 // Variables
 // --------------------------
 
+@use "sass:math";
+
 $fa-font-path:         "../webfonts" !default;
 $fa-font-size-base:    16px !default;
 $fa-font-display:      block !default;
@@ -9,7 +11,7 @@ $fa-version:           "5.13.0" !default;
 $fa-border-color:      #eee !default;
 $fa-inverse:           #fff !default;
 $fa-li-width:          2em !default;
-$fa-fw-width:          (20em / 16);
+$fa-fw-width:          math.div(20em, 16);
 $fa-primary-opacity:   1 !default;
 $fa-secondary-opacity: .4 !default;
 


### PR DESCRIPTION
Grunt is using Dart Sass now, stylesheet recompiled.
Due to _DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0._ all scss files were migrated to be Dart Sass 2.0 ready.